### PR TITLE
Update listing-3.12.js

### DIFF
--- a/listing-3.12.js
+++ b/listing-3.12.js
@@ -2,7 +2,7 @@
 
 const importCsvFromRestApi = require('./toolkit/importCsvFromRestApi.js');
 
-const url = "https://earthquake.usgs.gov/fdsnws/event/1/query.csv?starttime=2017-01-01&endtime=2017-03-02";
+const url = "https://earthquake.usgs.gov/fdsnws/event/1/query.csv?starttime=2017-01-01&endtime=2017-03-02&limit=20000";
 importCsvFromRestApi(url)
     .then(data => {
         console.log(data);


### PR DESCRIPTION
Limit search results to the API-defined max number (20k) so we avoid 400 error